### PR TITLE
Fix 'npm run dev' for folders with spaces

### DIFF
--- a/packages/@statusfy/core/lib/dev.js
+++ b/packages/@statusfy/core/lib/dev.js
@@ -19,7 +19,7 @@ module.exports = async function dev (sourceDir, cliOptions = {}) {
     script: path.join(__dirname, 'utils', 'start-dev.js'),
     watch: watchPaths,
     ext: '*',
-    exec: `cross-env STATUSFY_SOURCE_DIR=${sourceDir} STATUSFY_CLI_OPTIONS='${JSON.stringify(cliOptions)}' node`
+    exec: `cross-env STATUSFY_SOURCE_DIR='${sourceDir}' STATUSFY_CLI_OPTIONS='${JSON.stringify(cliOptions)}' node`
   })
 
   nodemon.on('start', () => {


### PR DESCRIPTION
<!-- Based on https://github.com/vuejs/vuepress/blob/master/.github/PULL_REQUEST_TEMPLATE.md -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
This PR will fix issue #92.

It will resolve this issue by adding quotation marks around the `STATUSFY_SOURCE_DIR` when running `cross-env` in `core/lib/dev.js`.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

**Other information:**
