### PR TITLE
Use docker multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,30 @@
+FROM node:8-alpine AS builder
+
+ENV STATUSFY_VERSION 0.3.1
+ENV NODE_ENV production
+
+WORKDIR /usr/src/app
+
+RUN \
+   set -x \
+&& yarn install \
+&& yarn add "statusfy@$STATUSFY_VERSION" \
+&& npx statusfy build
+
+
 FROM node:8-alpine
 
-RUN apk add --no-cache git
-
-# Set environment variables
-ENV USER_DIR=/usr/src/app
-ENV NODE_ENV production
-ENV STATUSFY_VERSION=0.3.1
 ENV NODE_ENV production
 ENV HOST 0.0.0.0
 ENV PORT 3000
+ENV WORKDIR /usr/src/app
 
-RUN mkdir -p $USER_DIR
-RUN chown node:node "$USER_DIR"
-WORKDIR $USER_DIR
-
-# RUN yarn cache clean
-# RUN yarn global add "statusfy@$STATUSFY_VERSION"
+COPY --from=builder --chown=node:node /usr/src/app/ $WORKDIR
 
 COPY ./scripts/docker-start.sh /start.sh
-RUN chmod +x /start.sh
 
-VOLUME $USER_DIR
+WORKDIR $WORKDIR
+VOLUME $WORKDIR
 EXPOSE $PORT
 
-CMD ["sh", "/start.sh"]
+CMD ["/start.sh"]

--- a/scripts/docker-start.sh
+++ b/scripts/docker-start.sh
@@ -1,10 +1,5 @@
-#!/bin/bash
+#!/bin/sh
+set -e
 
-cd $USER_DIR
-
-yarn cache clean
-NODE_ENV=development yarn install
-yarn add "statusfy@$STATUSFY_VERSION"
-
-npx statusfy build
+echo "Starting server..."
 npx statusfy start


### PR DESCRIPTION
**Summary**

Separate docker build environment from the run environment.

I was a tired of having to wait for the build to complete every time the image is run. Takes a long while.

from this:
```
yarn cache v1.12.3
success Cleared cache.
Done in 0.09s.
yarn install v1.12.3
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 0.23s.
yarn add v1.12.3
[1/4] Resolving packages...

[...]

ℹ Server listening on http://0.0.0.0:3000 

real    2m 0.39s
user    1m 9.75s
sys     0m 33.29s

```

to this:
```
Starting server...
ℹ Server listening on http://0.0.0.0:3000
 
real    0m 6.29s
user    0m 4.27s
sys     0m 1.19s
```

Although the size of the image has increased, it is orders of magnitude faster to start. I think it is justifiable.

Other minor changes:
* Remove `git`
* `scripts/docker-start.sh changed file mode from 100644 to 100755`
* Use `sh` for runtime
* Exit if any runtime error occurs

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [] Refactor
- [ ] Docs
- [] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature
- [X] Related documents have been updated (not applicable)
- [X] Related tests have been updated (not applicable)

**Other information:**

Not sure if feature is the best category for it.