### PR TITLE
fix: improve Gitpod port configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,9 @@
 ports:
 - port: 3000
+  onOpen: open-preview
 - port: 3001
+  onOpen: ignore
+- port: 8000
   onOpen: ignore
 tasks:
 - init: yarn


### PR DESCRIPTION
<!-- Based on https://github.com/vuejs/vuepress/blob/master/.github/PULL_REQUEST_TEMPLATE.md -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Hello! 👋 I noticed that when I open Statusfy in Gitpod, I currently get two notifications about ports `3000` and `8000`:

<img width="1552" alt="Screenshot 2019-08-09 at 16 26 36" src="https://user-images.githubusercontent.com/599268/62786500-ffd3c080-bac2-11e9-9db3-8dc6e1c1f53b.png">

I think it would be a nicer experience for developers if the appropriate action to take for each port is already pre-configured.

In this Pull Request, I chose to automatically open port `3000` in a Preview, and ignore port `8000`. Here is what the IDE looks like on start-up with my change (preview, no notification):

<img width="1552" alt="Screenshot 2019-08-09 at 16 26 52" src="https://user-images.githubusercontent.com/599268/62786603-3d384e00-bac3-11e9-978c-00be304ae1bb.png">

Please let me know what you think. 🙂 

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe: Config improvement

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
